### PR TITLE
Added a BufferLogger command to open a file with a timestamp

### DIFF
--- a/Svc/BufferLogger/BufferLogger.cpp
+++ b/Svc/BufferLogger/BufferLogger.cpp
@@ -156,4 +156,16 @@ namespace Svc {
     }
   }
 
+  void BufferLogger ::
+    BL_OpenFileTimestamp_cmdHandler(
+        const FwOpcodeType opCode,
+        const U32 cmdSeq,
+        const Fw::CmdStringArg& file
+    )
+  {
+    Fw::Time now = this->getTime();
+    m_file.setBaseNameTimestamp(file, now);
+    this->cmdResponse_out(opCode, cmdSeq, Fw::COMMAND_OK);
+  }
+
 };

--- a/Svc/BufferLogger/BufferLogger.hpp
+++ b/Svc/BufferLogger/BufferLogger.hpp
@@ -70,6 +70,12 @@ namespace Svc {
               const Fw::StringBase& baseName //!< The base file name; used with prefix, unique counter value, and suffix
           );
 
+          //! Set base file name and timestamp
+          void setBaseNameTimestamp(
+              const Fw::StringBase& baseName, //!< The base file name; used with prefix, unique counter value, and suffix
+              const Fw::Time timestamp
+          );
+
           //! Log a buffer
           void logBuffer(
               const U8 *const data, //!< The buffer data
@@ -147,6 +153,8 @@ namespace Svc {
 
           //! The number of bytes written to the current file
           U32 bytesWritten;
+
+          Fw::Time nameTimestamp;
 
       }; // class File
 
@@ -248,6 +256,14 @@ namespace Svc {
       void BL_FlushFile_cmdHandler(
           const FwOpcodeType opCode, /*!< The opcode*/
           const U32 cmdSeq /*!< The command sequence number*/
+      );
+
+      //! Implementation for BL_OpenFile command handler
+      //! Open a new log file with specified name and timestamp; required before activating logging
+      void BL_OpenFileTimestamp_cmdHandler(
+          const FwOpcodeType opCode, /*!< The opcode*/
+          const U32 cmdSeq, /*!< The command sequence number*/
+          const Fw::CmdStringArg& file
       );
 
   PRIVATE:

--- a/Svc/BufferLogger/Commands.xml
+++ b/Svc/BufferLogger/Commands.xml
@@ -28,4 +28,12 @@
     <comment>Flushes the current open log file to disk; a no-op with fprime's unbuffered file I/O, so always returns success</comment>
   </command>
 
+  <command kind="async" opcode="0x04" mnemonic="BL_OpenFileTimestamp">
+    <comment>Open a new log file with specified name and timestamp; also resets unique file counter to 0</comment>
+    <args>
+      <arg name="file" type="string" size = "40"/>
+    </args>
+  </command>
+
+
 </commands>

--- a/Svc/BufferLogger/test/ut/Logging.hpp
+++ b/Svc/BufferLogger/test/ut/Logging.hpp
@@ -41,6 +41,9 @@ namespace Svc {
         //! Test logging on/off capability
         void OnOff(void);
 
+        //! Test Open File Timestamp command
+        void OpenFileTimestamp(void);
+
     };
 
   }

--- a/Svc/BufferLogger/test/ut/Main.cpp
+++ b/Svc/BufferLogger/test/ut/Main.cpp
@@ -55,6 +55,11 @@ TEST(TestLogging, OnOff) {
   tester.OnOff();
 }
 
+TEST(TestLogging, OpenFileTimestamp) {
+  Svc::Logging::Tester tester;
+  tester.OpenFileTimestamp();
+}
+
 // ----------------------------------------------------------------------
 // Test Health
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Add a `BL_OpenFileTimestamp` command to BufferLoggers which will add a seconds and microseconds timestamp to data product filenames.
